### PR TITLE
Specify correct logback version to be used

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,7 @@ repositories {
 }
 
 def versions = [
+  logback: '1.2.3',
   reformLogging: '1.5.0',
   springBoot: springBoot.class.package.implementationVersion,
   springHystrix: '1.4.2.RELEASE',
@@ -75,6 +76,9 @@ dependencies {
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: versions.springBoot
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator', version: versions.springBoot
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-aop', version: versions.springBoot
+
+  compile group: 'ch.qos.logback', name: 'logback-classic', version: versions.logback
+  compile group: 'ch.qos.logback', name: 'logback-core', version: versions.logback
 
   compile group: 'io.springfox', name: 'springfox-swagger2', version: versions.springfoxSwagger
   compile group: 'io.springfox', name: 'springfox-swagger-ui', version: versions.springfoxSwagger

--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,8 @@ repositories {
   jcenter()
 }
 
+// it is important to specify logback classic and core packages explicitly as libraries like spring boot
+// enforces it's own (older) version which is not recommended.
 def versions = [
   logback: '1.2.3',
   reformLogging: '1.5.0',


### PR DESCRIPTION
### Change description ###

Spring Boot enforces it's own version of logback which is 1.1.11. Need to specifically state in the list of dependencies both classic and core libraries to be 1.2.3 - the latest. It is recommended for all spring boot projects which uses logstash incorporated in java-logging library

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
