### PR TITLE
Updated AbbreviationAsWordInName config as per defined in the sourceforge docs

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -177,8 +177,8 @@
       <property name="arrayInitIndent" value="4"/>
     </module>
     <module name="AbbreviationAsWordInName">
-      <property name="ignoreFinal" value="false"/>
-      <property name="allowedAbbreviationLength" value="1"/>
+      <property name="ignoreFinal" value="true"/>
+      <property name="allowedAbbreviationLength" value="3"/>
     </module>
     <module name="OverloadMethodsDeclarationOrder"/>
     <module name="VariableDeclarationUsageDistance"/>


### PR DESCRIPTION
Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###



### Change description ###

- Updated config as per source forge docs http://checkstyle.sourceforge.net/config_naming.html#AbbreviationAsWordInName


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```