### PR TITLE
Include implementation-version for installed jars

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,4 +97,8 @@ dependencies {
 // TODO: set the right name for your output jar. Must match the one specified in web.config.
 jar {
   archiveName 'spring-boot-template.jar'
+
+  manifest {
+    attributes('Implementation-Version': project.version.toString())
+  }
 }


### PR DESCRIPTION
As per [documentation](https://github.com/hmcts/java-logging/tree/master/java-logging-appinsights#product-version) in `java-logging-appinsights` module in order to populate project version in Azure portal we need to set MANIFEST.MF with `Implementation-Version`.

- Takes no affect if you don't use appinsights
- Can be used for other purposes at your will

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
