### PR TITLE
Upgrade jacoco

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,10 @@ pmd {
   ruleSetFiles = files("config/pmd/ruleset.xml")
 }
 
+jacoco {
+  toolVersion = "0.8.1"
+}
+
 jacocoTestReport {
   executionData(test)
   reports {


### PR DESCRIPTION
Will no longer report on untested private constructors in utility classes.