### PR TITLE
[HOTFIX] Fix correct guava version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,6 +131,11 @@ def versions = [
 ]
 
 dependencyManagement {
+  dependencies {
+    dependencySet(group: 'com.google.guava', version: '20.0') {
+      entry 'guava'
+    }
+  }
   imports {
     mavenBom "org.springframework.boot:spring-boot-dependencies:${versions.springBoot}"
     mavenBom "org.springframework.cloud:spring-cloud-dependencies:${versions.springCloud}"


### PR DESCRIPTION
Missed dependency fix for guava. Incompatible among older versions getting selected by spring dependency manager causes checkstyle fail.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
