### PR TITLE
Make script init more human friendly

### DIFF
--- a/bin/init.sh
+++ b/bin/init.sh
@@ -1,39 +1,27 @@
 #!/usr/bin/env sh
 #
 # Script to initialise project by executing steps as follows:
-#   - Replace port number with given 1st argument
-#   - Replace package name from `demo` to given 2nd argument
+#   - Replace port number
+#   - Replace package `demo`
 #   - Replace slug from `spring-boot-template` to one of two (first in first used):
-#      - 3rd argument
+#      - user input
 #      - git config value of the root project. Value in use: `remote.origin.url`
 #   - Clean-up README file from template related info
 #   - Self-destruct
 
-if [ "$#" -le 1 ]
-then
-  echo "Usage: $0 port package [slug]
+read -p "Port number for new app: " port
+read -p "Replace \`demo\` package name with: " package
 
-  If slug is not present script will try to pick it up from git config, remote.origin.url
-  "
-  exit 0
-fi
+git_slug=$(git config remote.origin.url | cut -d '/' -f 2)
+slug=${git_slug%.*}
+
+read -p "Repo slug: (leave blank for \"$slug\") " new_slug
 
 cd $(dirname "$0")/..
 
-port=$1
-package=$2
-slug=$3
-
-if [[ -z  "$slug"  ]]
+if [[ ! -z  "$new_slug"  ]]
 then
-  git_slug=$(git config remote.origin.url | cut -d '/' -f 2)
-  slug=${git_slug%.*}
-fi
-
-if [[ -z  "$slug"  ]]
-then
-  echo "Could not find any slug"
-  exit 1
+  slug="$new_slug"
 fi
 
 declare -a files_with_port=(.env Dockerfile README.md src/main/resources/application.yaml)

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -41,6 +41,7 @@ done
 
 # Replace demo package in all files under ./src
 find ./src -type f -print0 | xargs -0 sed -i '' "s/reform.demo/reform.$package/g"
+sed -i '' "s/reform.demo/reform.$package/g" build.gradle
 
 # Rename directory to provided package name
 cd src/main/java/uk/gov/hmcts/reform


### PR DESCRIPTION
Before:
```
$ ./bin/init.sh port package [slug]
```
Now:
```
$ ./bin/init.sh
Port number for new app: 1234
Replace `demo` package name with: omed
Repo slug: (leave blank for "spring-boot-template") some-slug
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
