### PR TITLE
Fix init script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: java
 
+branches:
+  only:
+    - master
+
 #services:
 #  - docker
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ To build the project execute the following command:
 Create the image of the application by executing the following command:
 
 ```bash
-  ./gradlew installDist
+  ./gradlew assemble
 ```
 
 Create docker image:

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -44,17 +44,9 @@ find ./src -type f -print0 | xargs -0 sed -i '' "s/reform.demo/reform.$package/g
 sed -i '' "s/reform.demo/reform.$package/g" build.gradle
 
 # Rename directory to provided package name
-cd src/main/java/uk/gov/hmcts/reform
-
-mv demo ${package}
-
-cd $(dirname "$0")/..
-
-cd src/test/java/uk/gov/hmcts/reform
-
-mv demo ${package}
-
-cd $(dirname "$0")/..
+mv src/integrationTest/java/uk/gov/hmcts/reform/demo src/integrationTest/java/uk/gov/hmcts/reform/${package}
+mv src/main/java/uk/gov/hmcts/reform/demo src/main/java/uk/gov/hmcts/reform/${package}
+mv src/test/java/uk/gov/hmcts/reform/demo src/test/java/uk/gov/hmcts/reform/${package}
 
 declare -a headers_to_delete=("Purpose" "What's inside" "Plugins" "Hystrix")
 

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -25,7 +25,7 @@ then
 fi
 
 declare -a files_with_port=(.env Dockerfile README.md src/main/resources/application.yaml)
-declare -a files_with_slug=(build.gradle docker-compose.yml Dockerfile README.md web.config src/main/uk/gov/hmcts/reform/demo/controllers/RootController.java)
+declare -a files_with_slug=(build.gradle docker-compose.yml Dockerfile README.md web.config ./src/main/java/uk/gov/hmcts/reform/demo/controllers/RootController.java)
 
 # Replace port number
 for i in ${files_with_port[@]}

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -48,7 +48,7 @@ mv src/integrationTest/java/uk/gov/hmcts/reform/demo src/integrationTest/java/uk
 mv src/main/java/uk/gov/hmcts/reform/demo src/main/java/uk/gov/hmcts/reform/${package}
 mv src/test/java/uk/gov/hmcts/reform/demo src/test/java/uk/gov/hmcts/reform/${package}
 
-declare -a headers_to_delete=("Purpose" "What's inside" "Plugins" "Hystrix")
+declare -a headers_to_delete=("Purpose" "What's inside" "Plugins" "Setup" "Hystrix")
 
 # Clean-up README file
 for i in "${headers_to_delete[@]}"

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -17,7 +17,7 @@ slug=${git_slug%.*}
 
 read -p "Repo slug: (leave blank for \"$slug\") " new_slug
 
-cd $(dirname "$0")/..
+cd $(realpath $(dirname "$0")/..)
 
 if [[ ! -z  "$new_slug"  ]]
 then

--- a/build.gradle
+++ b/build.gradle
@@ -154,6 +154,7 @@ dependencies {
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: versions.springBoot
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator', version: versions.springBoot
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-aop', version: versions.springBoot
+  compile group: 'org.springframework.boot', name: 'spring-boot-starter-json', version: versions.springBoot
 
   compile group: 'io.springfox', name: 'springfox-swagger2', version: versions.springfoxSwagger
   compile group: 'io.springfox', name: 'springfox-swagger-ui', version: versions.springfoxSwagger


### PR DESCRIPTION
Was missing few bits:
- correct path to root controller
- normal way of renaming the directory
- fix for absolute path of the script/project

Bonus:
- include `spring-boot-starter-json` introduced since spring boot 2
- build only against master to reduce travis resources and github api hit rota

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
