### PR TITLE
Fix Spring Boot 2 actuator endpoints

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,6 +1,11 @@
 server:
   port: 4550
 
+management:
+  endpoints:
+    web:
+      base-path: /
+
 #If you use a database then uncomment below lines and update db properties accordingly leaving tomcat connection settings unchanged.
 spring:
   application:


### PR DESCRIPTION
Since Spring Boot 2 actuator endpoints (e.g. `/info`, `/health`) are under `/actuator`. This PR will fix our health checks and build pipelines

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
