### PR TITLE
Remove hystrix dashboard dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ The template is a working application with a minimal setup. It contains:
  * code quality tools already set up
  * integration with Travis CI
  * Hystrix circuit breaker enabled
- * Hystrix dashboard
  * MIT license and contribution information
 
 The application exposes health endpoint (http://localhost:4550/health) and metrics endpoint
@@ -183,15 +182,6 @@ and providing fallback options. We recommend you to use Hystrix in your applicat
 This template API has [Hystrix Circuit Breaker](https://github.com/Netflix/Hystrix/wiki/How-it-Works#circuit-breaker)
 already enabled. It monitors and manages all the`@HystrixCommand` or `HystrixObservableCommand` annotated methods
 inside `@Component` or `@Service` annotated classes.
-
-### Hystrix dashboard
-
-When this API is running, you can monitor Hystrix metrics in real time using
-[Hystrix Dashboard](https://github.com/Netflix/Hystrix/wiki/Dashboard).
-In order to do this, visit http://localhost:4550/hystrix and provide http://localhost:4550/hystrix.stream
-as the Hystrix event stream URL. Keep in mind that you'll only see data once some
-of your Hystrix commands have been executed. Otherwise *'Loading...'* message will be displayed
-on the monitoring page.
 
 ### Other
 

--- a/build.gradle
+++ b/build.gradle
@@ -121,7 +121,6 @@ repositories {
 def versions = [
   reformLogging: '3.0.1',
   springBoot: springBoot.class.package.implementationVersion,
-  springHystrix: '2.0.0.RELEASE',
   springfoxSwagger: '2.9.2'
 ]
 
@@ -135,8 +134,7 @@ dependencies {
   compile group: 'io.springfox', name: 'springfox-swagger-ui', version: versions.springfoxSwagger
 
   compile group: 'uk.gov.hmcts.reform', name: 'java-logging', version: versions.reformLogging
-  compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-hystrix', version: versions.springHystrix
-  compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-hystrix-dashboard', version: versions.springHystrix
+  compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-hystrix', version: '2.0.1.RELEASE'
 
   testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot
 

--- a/src/main/java/uk/gov/hmcts/reform/demo/Application.java
+++ b/src/main/java/uk/gov/hmcts/reform/demo/Application.java
@@ -3,11 +3,9 @@ package uk.gov.hmcts.reform.demo;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.circuitbreaker.EnableCircuitBreaker;
-import org.springframework.cloud.netflix.hystrix.dashboard.EnableHystrixDashboard;
 
 @SpringBootApplication
 @EnableCircuitBreaker
-@EnableHystrixDashboard
 @SuppressWarnings("HideUtilityClassConstructor") // Spring needs a constructor, its not a utility class
 public class Application {
 


### PR DESCRIPTION
### Change description ###

Removing hystrix dashboard as it is not used anyway. Hystrix circuit breaker is highly recommended to be used in any service - it is up to the project developers to integrate/disregard it

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
