### PR TITLE
Remove resource group definition

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -1,11 +1,5 @@
 provider "azurerm" {}
 
-# Make sure the resource group exists
-resource "azurerm_resource_group" "rg" {
-  name     = "${var.product}-${var.component}-${var.env}"
-  location = "${var.location_app}"
-}
-
 locals {
   ase_name               = "${data.terraform_remote_state.core_apps_compute.ase_name[0]}"
 }


### PR DESCRIPTION
Its defined in module web app, having it in main.tf means tagging doesn't get applied

