### PR TITLE
Update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
   id 'pmd'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.6.RELEASE'
-  id 'org.springframework.boot' version '2.0.3.RELEASE'
+  id 'org.springframework.boot' version '2.0.6.RELEASE'
   id 'org.owasp.dependencycheck' version '3.3.4'
   id 'com.github.ben-manes.versions' version '0.20.0'
   id 'org.sonarqube' version '2.6.2'
@@ -147,7 +147,7 @@ dependencies {
   compile group: 'io.springfox', name: 'springfox-swagger-ui', version: versions.springfoxSwagger
 
   compile group: 'uk.gov.hmcts.reform', name: 'java-logging', version: versions.reformLogging
-  compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-hystrix', version: '2.0.1.RELEASE'
+  compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-hystrix', version: '2.0.2.RELEASE'
 
   testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,9 @@ plugins {
   id 'checkstyle'
   id 'pmd'
   id 'jacoco'
-  id 'io.spring.dependency-management' version '1.0.5.RELEASE'
+  id 'io.spring.dependency-management' version '1.0.6.RELEASE'
   id 'org.springframework.boot' version '2.0.3.RELEASE'
-  id 'org.owasp.dependencycheck' version '3.2.1'
+  id 'org.owasp.dependencycheck' version '3.3.4'
   id 'com.github.ben-manes.versions' version '0.20.0'
   id 'org.sonarqube' version '2.6.2'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ checkstyle {
 }
 
 pmd {
-  toolVersion = "6.5.0"
+  toolVersion = "6.9.0"
   ignoreFailures = true
   sourceSets = [sourceSets.main, sourceSets.test, sourceSets.functionalTest, sourceSets.integrationTest, sourceSets.smokeTest]
   reportsDir = file("$project.buildDir/reports/pmd")

--- a/build.gradle
+++ b/build.gradle
@@ -132,7 +132,7 @@ repositories {
 // it is important to specify logback classic and core packages explicitly as libraries like spring boot
 // enforces it's own (older) version which is not recommended.
 def versions = [
-  reformLogging: '3.0.1',
+  reformLogging: '3.0.2',
   springBoot: springBoot.class.package.implementationVersion,
   springfoxSwagger: '2.9.2'
 ]

--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ task smoke(type: Test) {
 
 checkstyle {
   maxWarnings = 0
-  toolVersion = '8.10.1'
+  toolVersion = '8.14'
   // need to set configDir to rootDir otherwise submodule will use submodule/config/checkstyle
   configDir = new File(rootDir, 'config/checkstyle')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,6 @@ checkstyle {
 
 pmd {
   toolVersion = "6.9.0"
-  ignoreFailures = true
   sourceSets = [sourceSets.main, sourceSets.test, sourceSets.functionalTest, sourceSets.integrationTest, sourceSets.smokeTest]
   reportsDir = file("$project.buildDir/reports/pmd")
   ruleSetFiles = files("config/pmd/ruleset.xml")

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -11,26 +11,19 @@ spring:
   application:
     name: Spring Boot Template
 #  datasource:
-#    url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}
+#    driver-class-name: org.postgresql.Driver
+#    url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}${DB_OPTIONS:}
 #    username: ${DB_USER_NAME}
 #    password: ${DB_PASSWORD}
 #    properties:
 #      charSet: UTF-8
-#    tomcat:
-#      max-active: 10
-#      max-idle: 10
-#      min-idle: 2
-#      max-wait: 10000
-#      test-on-borrow: true
-#      test-on-connect: true
-#      validation-query: "SELECT 1"
-#      time-between-eviction-runs-millis: 10000
-#      test-while-idle: true
-#      test-on-return: true
-#      remove-abandoned: true
-#      remove-abandoned-timeout: 60
-#      log-abandoned: true
-#      abandon-when-percentage-full: 0
+#    hikari:
+#      minimumIdle: 2
+#      maximumPoolSize: 10
+#      idleTimeout: 10000
+#      poolName: {to-be-defined}HikariCP
+#      maxLifetime: 7200000
+#      connectionTimeout: 30000
 #  jpa:
 #    properties:
 #      hibernate:


### PR DESCRIPTION
### Change description ###

No plugin yet enabled and since started overviewing the template, might as well have a look at latest setup. Spring Boot version jump to 2.1 has been left aside as it needs more information to be provided in the repo - best to keep the upgrade separate.

Application configuration sample for db has been updated to reflect the altered preferences of Spring Boot since v2. Amend the sample as needed

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
