### PR TITLE
Replace use of cd and realpath with pushd/popd

### DIFF
--- a/bin/init.sh
+++ b/bin/init.sh
@@ -17,7 +17,7 @@ slug=${git_slug%.*}
 
 read -p "Repo slug: (leave blank for \"$slug\") " new_slug
 
-pushd $(dirname "$0")/..) > /dev/null
+pushd $(dirname "$0")/.. > /dev/null
 
 if [[ ! -z  "$new_slug"  ]]
 then

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -17,7 +17,7 @@ slug=${git_slug%.*}
 
 read -p "Repo slug: (leave blank for \"$slug\") " new_slug
 
-cd $(realpath $(dirname "$0")/..)
+pushd $(dirname "$0")/..) > /dev/null
 
 if [[ ! -z  "$new_slug"  ]]
 then
@@ -60,3 +60,6 @@ perl -i -pe "s/.*\n/# $slug\n/g if 1 .. 1" README.md
 
 # Self-destruct
 rm bin/init.sh
+
+# Return to original directory
+popd > /dev/null


### PR DESCRIPTION
PR to fix issue #74 

Replaces cd with pushd/popd and removes the call to realpath as it's not necessary. Any successful invocation of the script from an interactive terminal (which it needs anyway) should have a perfectly valid path that can be given to pushd/popd