### PR TITLE
terraform can't fetch a resource definition that is not here yet.

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -10,7 +10,6 @@ module "spring-boot-template" {
   location            = "${var.location_app}"
   env                 = "${var.env}"
   ilbIp               = "${var.ilbIp}"
-  resource_group_name = "${azurerm_resource_group.rg.name}"
   subscription        = "${var.subscription}"
   capacity            = "${var.capacity}"
   common_tags         = "${var.common_tags}"


### PR DESCRIPTION
resource_group_name should be automatically built by the default value
down the app module. 
https://github.com/hmcts/cnp-module-webapp/blob/master/main.tf#L3

don't need to have it. it is already build into the module.

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
