### PR TITLE
Fix dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -2,5 +2,4 @@ version: 1
 update_configs:
   - package_manager: "java:gradle"
     directory: "/"
-    update_schedule: "live"
-
+    update_schedule: "daily"


### PR DESCRIPTION
https://dependabot.com/docs/config-file/
live

Only supported by the following package managers

javascript
ruby:bundler
python
php:composer
dotnet:nuget
rust:cargo
elixir:hex