### PR TITLE
Add additional intellij editorconfig features

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,13 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+max_line_length = 120
 
 [*.java]
 indent_size = 4
+ij_continuation_indent_size = 4
+ij_java_align_multiline_parameters = true
+ij_java_align_multiline_parameters_in_calls = true
+ij_java_call_parameters_new_line_after_left_paren = true
+ij_java_call_parameters_right_paren_on_new_line = true
+ij_java_call_parameters_wrap = on_every_item


### PR DESCRIPTION
### Change description ###
Prevent things like:
```
longServiceName.longMethodName(longParamXX,
            longParamYY, longParamZZ);
```
and default to this instead:
```
longServiceName.longMethodName(
    longParamXX,
    longParamYY,
    longParamZZ
);
```

See: https://github.com/hmcts/bulk-scan-processor/pull/732

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
