### PR TITLE
Remove java-logging-spring

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -176,7 +176,6 @@ dependencies {
   compile group: 'io.springfox', name: 'springfox-swagger2', version: versions.springfoxSwagger
 
   compile group: 'uk.gov.hmcts.reform', name: 'java-logging', version: versions.reformLogging
-  compile group: 'uk.gov.hmcts.reform', name: 'java-logging-spring', version: versions.reformLogging
   compile group: 'uk.gov.hmcts.reform', name: 'java-logging-appinsights', version: versions.reformLogging
   compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-hystrix', version: '2.1.2.RELEASE'
 


### PR DESCRIPTION
This logs a message on every request with how long it took, it's annoying log spam in most cases, and app insights does this for us
