### PR TITLE
Downgrade spring boot

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
   id 'pmd'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.9.RELEASE'
-  id 'org.springframework.boot' version '2.3.2.RELEASE'
+  id 'org.springframework.boot' version '2.3.1.RELEASE'
   id 'org.owasp.dependencycheck' version '5.3.2.1'
   id 'com.github.ben-manes.versions' version '0.29.0'
   id 'org.sonarqube' version '3.0'


### PR DESCRIPTION
Downgrade spring boot as the version used previously 2.3.2.RELEASE has an issue
with serving the readiness and liveness endpoints.