### PR TITLE
Fix empty environment variables

### DIFF
--- a/charts/rpe-spring-boot-template/values.preview.template.yaml
+++ b/charts/rpe-spring-boot-template/values.preview.template.yaml
@@ -1,5 +1,4 @@
 java:
-  environment:
   # Don't modify below here
   image: ${IMAGE_NAME}
   ingressHost: ${SERVICE_FQDN}


### PR DESCRIPTION
Remove empty environment section as this will overwrite any environment variables set in values.yaml which means
they are not set for PR builds. This can be really confusing if you are setting them and then they do not appear
on your PR builds. Probably better to have this so you have to add it in rather than there by default.