### PR TITLE
DTSPO-1875 - use mavencentral repo before jcenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -155,8 +155,8 @@ dependencyManagement {
 
 repositories {
   mavenLocal()
-  jcenter()
   mavenCentral()
+  jcenter()
 }
 
 def versions = [


### PR DESCRIPTION
### Change description ###
- Use mavenCentral repo before trying jcenter
