### PR TITLE
Update template

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -17,6 +17,7 @@ springdoc:
 #If you use a database then uncomment below lines and update db properties accordingly
 spring:
   config:
+    #Append your team name to this file path: e.g "optional:configtree:/mnt/secrets/rpts/"
     import: "optional:configtree:/mnt/secrets/"
   application:
     name: Spring Boot Template


### PR DESCRIPTION
Team experience postgres auth issues and updating the `import:` line fixed their problems. 

Have found other examples of teams overriding this: 
-https://github.com/hmcts/send-letter-service/blob/3a527d4a0d79ff67c0378d5d8e8693dd9941e442/src/main/resources/application.yaml#L27 
-https://github.com/hmcts/em-annotation-api/blob/ddb56ba36a78e1c39a58abadfca7a581dbcda77f/src/main/resources/application.yaml#L7 
-https://github.com/hmcts/draft-store/blob/717e83858b84f950dc70ca233298e1ed5aa07593/src/main/resources/application.yaml#L16

Unsure if `team name` is the correct thing to append or it should be something else like product

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
