### PR TITLE
Updated GitHub actions versions in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.1.0
-      - uses: actions/setup-java@v3.6.0
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
         with:
           distribution: 'temurin' # See 'Supported distributions' for available options
           java-version: '11'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2
+      - uses: actions/checkout@v3.1.0
+      - uses: actions/setup-java@v3.6.0
         with:
           distribution: 'temurin' # See 'Supported distributions' for available options
           java-version: '11'


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Updated the versions of the GitHub actions used in CI workflow.  This resolves warnings about the use of deprecated features when the workflow is executed.

For reference the warnings were:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/ https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
