### PR TITLE
DTSPO-13135 Add OpenAPI publishing by default

### DIFF
--- a/.github/workflows/publish-openapi.yaml
+++ b/.github/workflows/publish-openapi.yaml
@@ -1,0 +1,14 @@
+name: Publish OpenAPI specs
+on:
+  push:
+    branches:
+      - "master"
+
+jobs:
+  publish-openapi:
+    uses: hmcts/workflow-publish-openapi-spec/.github/workflows/publish-openapi.yml@v1
+    secrets:
+      SWAGGER_PUBLISHER_API_TOKEN: ${{ secrets.SWAGGER_PUBLISHER_API_TOKEN }}
+    with:
+      test_to_run: 'uk.gov.hmcts.demo.openapi.OpenAPIPublisherTest'
+      java_version: 17

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Spring Boot application template
 
-[![Build Status](https://travis-ci.org/hmcts/spring-boot-template.svg?branch=master)](https://travis-ci.org/hmcts/spring-boot-template)
-
 ## Purpose
 
 The purpose of this template is to speed up the creation of new Spring applications within HMCTS
@@ -15,10 +13,8 @@ The template is a working application with a minimal setup. It contains:
  * setup script to prepare project
  * common plugins and libraries
  * docker setup
- * swagger configuration for api documentation ([see how to publish your api documentation to shared repository](https://github.com/hmcts/reform-api-docs#publish-swagger-docs))
+ * automatically publishes API documentation to [hmcts/cnp-api-docs](https://github.com/hmcts/cnp-api-docs)
  * code quality tools already set up
- * integration with Travis CI
- * Hystrix circuit breaker enabled
  * MIT license and contribution information
  * Helm chart using chart-java.
 
@@ -91,12 +87,6 @@ The template contains the following plugins:
 ## Setup
 
 Located in `./bin/init.sh`. Simply run and follow the explanation how to execute it.
-
-## Notes
-
-Since Spring Boot 2.1 bean overriding is disabled. If you want to enable it you will need to set `spring.main.allow-bean-definition-overriding` to `true`.
-
-JUnit 5 is now enabled by default in the project. Please refrain from using JUnit4 and use the next generation
 
 ## Building and deploying the application
 
@@ -176,16 +166,6 @@ docker image rm <image-id>
 ```
 
 There is no need to remove postgres and java or similar core images.
-
-### Other
-
-Hystrix offers much more than Circuit Breaker pattern implementation or command monitoring.
-Here are some other functionalities it provides:
- * [Separate, per-dependency thread pools](https://github.com/Netflix/Hystrix/wiki/How-it-Works#isolation)
- * [Semaphores](https://github.com/Netflix/Hystrix/wiki/How-it-Works#semaphores), which you can use to limit
- the number of concurrent calls to any given dependency
- * [Request caching](https://github.com/Netflix/Hystrix/wiki/How-it-Works#request-caching), allowing
- different code paths to execute Hystrix Commands without worrying about duplicating work
 
 ## License
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/demo/openapi/OpenAPIPublisherTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/demo/openapi/OpenAPIPublisherTest.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.reform.demo.config;
+package uk.gov.hmcts.reform.demo.openapi;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,7 +23,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
-class SwaggerPublisherTest {
+class OpenAPIPublisherTest {
 
     @Autowired
     private MockMvc mvc;
@@ -38,7 +38,7 @@ class SwaggerPublisherTest {
             .getResponse()
             .getContentAsByteArray();
 
-        try (OutputStream outputStream = Files.newOutputStream(Paths.get("/tmp/swagger-specs.json"))) {
+        try (OutputStream outputStream = Files.newOutputStream(Paths.get("/tmp/openapi-specs.json"))) {
             outputStream.write(specs);
         }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,6 +13,7 @@ management:
 
 springdoc:
   packagesToScan: uk.gov.hmcts.reform.demo.controllers
+  writer-with-order-by-keys: true
 
 #If you use a database then uncomment below lines and update db properties accordingly
 spring:


### PR DESCRIPTION
see 
- https://github.com/hmcts/workflow-publish-openapi-spec/pull/1
- https://github.com/hmcts/.github/pull/12

People no longer need to set this up themselves separately and we only have one central workflow for the simple case, people can customise it if they need to