### PR TITLE
Use organisation preset for renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>hmcts/.github//renovate/global",
-    "github>hmcts/.github//renovate/automerge-all"
+    "local>hmcts/.github:renovate-config"
+    "local>hmcts/.github//renovate/automerge-all"
   ]
 }


### PR DESCRIPTION
see https://docs.renovatebot.com/config-presets/#organization-level-presets

and
https://github.com/hmcts/.github/pull/19

Used local to be consistent with the onboarding PR:
https://github.com/hmcts/nodejs-info-provider/pull/41