### PR TITLE
Sample health requests aggressively

### DIFF
--- a/lib/applicationinsights.json
+++ b/lib/applicationinsights.json
@@ -2,5 +2,22 @@
   "connectionString": "${file:/mnt/secrets/rpe/app-insights-connection-string}",
   "role": {
     "name": "rpe-demo"
+  },
+  "preview": {
+    "sampling": {
+      "overrides": [
+        {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/health.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 1
+        }
+      ]
+    }
   }
 }


### PR DESCRIPTION
There's no need to ingest all health requests we get millions of them in our telemetry, even 1% should be enough to see issues