### PR TITLE
Update PMD BeanMembersShouldSerialize exclusion

### DIFF
--- a/config/pmd/ruleset.xml
+++ b/config/pmd/ruleset.xml
@@ -63,7 +63,7 @@
     <exclude name="UncommentedEmptyMethodBody"/>
   </rule>
   <rule ref="category/java/errorprone.xml">
-    <exclude name="BeanMembersShouldSerialize"/>
+    <exclude name="NonSerializableClass"/>
   </rule>
   <rule ref="category/java/multithreading.xml"/>
   <rule ref="category/java/performance.xml"/>


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
The BeanMembersShouldSerialize rule has been deprecated since PMD version 6.52.0.  It has been replaced with NonSerializableClass (see https://pmd.github.io/pmd/pmd_rules_java_errorprone.html#beanmembersshouldserialize).  Changed exclusion for BeanMembersShouldSerialize in PMD ruleset.xml to NonSerializableClass.

The change will prevent a "Unable to exclude rules [BeanMembersShouldSerialize] from ruleset reference category/java/errorprone.xml; perhaps the rule name is misspelled or the rule doesn't exist anymore?" messages being displayed in the build output.

A number of projects using this template have already made this change (e.g. https://github.com/hmcts/sscs-hearings-api/blob/master/config/pmd/ruleset.xml#L66).


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
