### PR TITLE
Remove dependency check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,5 +20,3 @@ jobs:
           cache: 'gradle'
       - name: Build
         run: ./gradlew check
-      - name: Dependency check
-        run: ./gradlew dependencyCheckAggregate


### PR DESCRIPTION
Needs an API key otherwise it's too slow, this is done by Jenkins anyway