### PR TITLE
Upgrade appinsights agent to 3.5.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
  # renovate: datasource=github-releases depName=microsoft/ApplicationInsights-Java
-ARG APP_INSIGHTS_AGENT_VERSION=3.4.18
+ARG APP_INSIGHTS_AGENT_VERSION=3.5.2
 FROM hmctspublic.azurecr.io/base/java:21-distroless
 
 COPY lib/applicationinsights.json /opt/app/

--- a/lib/applicationinsights.json
+++ b/lib/applicationinsights.json
@@ -3,21 +3,19 @@
   "role": {
     "name": "rpe-demo"
   },
-  "preview": {
-    "sampling": {
-      "overrides": [
-        {
-          "telemetryType": "request",
-          "attributes": [
-            {
-              "key": "http.url",
-              "value": "https?://[^/]+/health.*",
-              "matchType": "regexp"
-            }
-          ],
-          "percentage": 1
-        }
-      ]
-    }
+  "sampling": {
+    "overrides": [
+      {
+        "telemetryType": "request",
+        "attributes": [
+          {
+            "key": "http.url",
+            "value": "https?://[^/]+/health.*",
+            "matchType": "regexp"
+          }
+        ],
+        "percentage": 1
+      }
+    ]
   }
 }


### PR DESCRIPTION
Incorporates https://github.com/hmcts/spring-boot-template/pull/570

Adapting to https://github.com/microsoft/ApplicationInsights-Java/pull/3463